### PR TITLE
Add `ember-mocha` example tests

### DIFF
--- a/test/calc-dist-tag-test.js
+++ b/test/calc-dist-tag-test.js
@@ -92,4 +92,11 @@ describe('calcDistTag()', function() {
   test('3.1.0-beta.2', { latest: '3.0.3', beta: '3.1.0-beta.1' }, 'beta');
   test('3.1.0', { latest: '3.0.3', beta: '3.1.0-beta.2' }, 'latest');
 
+  // real world: ember-cli-mocha
+  test('0.12.0', { latest: '0.11.1' }, 'latest');
+  test('0.13.0-beta.1', { latest: '0.12.0' }, 'beta');
+
+  // real world: ember-mocha
+  test('0.14.4', { latest: '0.14.3' }, 'latest');
+  test('0.14.5-beta.1', { latest: '0.14.4' }, 'beta');
 });


### PR DESCRIPTION
This adds tests that should prevent https://github.com/Turbo87/auto-dist-tag/issues/10 from happening again in the future. Unfortunately it seems that these tests are already passing, so https://github.com/Turbo87/auto-dist-tag/issues/10 must have been caused by something unrelated 🤔 