### PR TITLE
Drop support for Node.js 6 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
   - 10
-  - 8
-  - 6
+  - 12
+  - 14
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jest": "^22.4.3"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=10"
   },
   "jest": {
     "testMatch": [


### PR DESCRIPTION
... and add Node.js 12 and 14 to the test matrix instead.
