### PR TITLE
CI: Use `npm` for publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,6 @@ jobs:
       - name: auto-dist-tag
         run: pnpx auto-dist-tag@1 --write
 
-      - run: pnpm publish
+      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
`pnpm` appears to have some problems... see https://github.com/Turbo87/auto-dist-tag/runs/2311973647