### PR TITLE
CI: Pin action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         node-version: ["10", "12", "14"]
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-node@v2.5.1
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -43,8 +43,8 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3.1.0
+      - uses: actions/setup-node@v2.5.1
         with:
           node-version: 10
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
We'd rather update them explicitly, or have renovatebot update them for us, but we don't want to implicitly opt into new versions that might unintentionally break things.